### PR TITLE
Externalize te cacheloader to the location of VG_HOME

### DIFF
--- a/verigreen-collector-impl/src/main/resources/configurations/jbossCacheConfig.xml
+++ b/verigreen-collector-impl/src/main/resources/configurations/jbossCacheConfig.xml
@@ -27,7 +27,7 @@ See the License for the specific language governing permissions and limitations 
 		<loader class="org.jboss.cache.loader.FileCacheLoader" async="false"
 			fetchPersistentState="true">
 			<properties>
-				location=cacheloader
+				location=/${env.VG_HOME}/cacheloader
 			</properties>
 		</loader>
 	</loaders>


### PR DESCRIPTION
Tested on 14 october with bash and tcsh
