### PR TITLE
Failed parent should also reset the retry mechanism counters for its'…

### DIFF
--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/decision/decisionmaker/DecisionMakerFailedItems.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/decision/decisionmaker/DecisionMakerFailedItems.java
@@ -122,6 +122,8 @@ public class DecisionMakerFailedItems {
                     e));
 		}
         item.setBuildNumber(0);
+        item.setRetriableCounter(0);
+        item.setTimeoutCounter(0);
         item.setStatus(VerificationStatus.NOT_STARTED);
         CollectorApi.getCommitItemContainer().save(item);
         houseOfCards(item.getChild(), decisions);


### PR DESCRIPTION
… children.

Testing:
-   3 commits, A, B and C
-   A is running
-   Changed the jobname
-   Started B & C
-   Waited for B & C to get TRIGGER_FAILED
-   Changed jobname back
-   Cancelled A -> A is FAILED
-   A restarts B & C but they have the old counters

A fix has been implemented for this issue.
