### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/git-hook/src/com/verigreen/common/spring/GitHookApi.java
+++ b/git-hook/src/com/verigreen/common/spring/GitHookApi.java
@@ -19,7 +19,10 @@ import com.verigreen.common.concurrency.RuntimeUtils;
 import com.verigreen.common.spring.SpringContextHolder;
 
 public class GitHookApi {
-    
+
+    private GitHookApi() {
+    }
+
     public static CreateBranchRequest getCreateBranchRequest(BranchDescriptor branchDescriptor) {
         
         return RuntimeUtils.cast(getBean(

--- a/git-hook/src/com/verigreen/hook/EntryPoint.java
+++ b/git-hook/src/com/verigreen/hook/EntryPoint.java
@@ -21,7 +21,10 @@ import com.verigreen.common.concurrency.RuntimeUtils;
 import com.verigreen.common.spring.SpringContextLoader;
 
 public class EntryPoint {
-    
+
+    private EntryPoint() {
+    }
+
     public static void main(String[] args) throws IOException, InterruptedException {
         
         initialize();

--- a/verigreen-collector-api/src/com/verigreen/spring/common/CollectorApi.java
+++ b/verigreen-collector-api/src/com/verigreen/spring/common/CollectorApi.java
@@ -19,7 +19,10 @@ import com.verigreen.common.concurrency.RuntimeUtils;
 import com.verigreen.common.spring.SpringContextHolder;
 
 public class CollectorApi {
-    
+
+    private CollectorApi() {
+    }
+
     public static String getCollectorAddress() {
     	String address = RuntimeUtils.cast(getBean("collectorAddress"));
     	return address;    

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/common/CommitItemUtils.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/common/CommitItemUtils.java
@@ -35,6 +35,9 @@ import com.verigreen.common.utils.LocalMachineCurrentTimeProvider;
 
 public class CommitItemUtils {
 
+	private CommitItemUtils() {
+	}
+
 	public static Collection<CommitItem> filterItems(
             Collection<CommitItem> items,
             final VerificationStatus state) {

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/rest/CommitMessage.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/rest/CommitMessage.java
@@ -33,6 +33,9 @@ import com.verigreen.collector.common.VerigreenNeededLogic;
 
 @Path("/commit-message")
 public class CommitMessage {
+	private CommitMessage() {
+	}
+
 	@GET
     @Produces(MediaType.APPLICATION_JSON)
 	public static Response get() {

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/spring/CollectorApi.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/spring/CollectorApi.java
@@ -32,7 +32,10 @@ import com.verigreen.common.spring.SpringContextHolder;
 import com.verigreen.jgit.SourceControlOperator;
 
 public class CollectorApi {
-    
+
+    private CollectorApi() {
+    }
+
     public static CacheInstance getCache() {
         
         return getBean(CacheInstance.class);

--- a/verigreen-collector-impl/src/test/java/com/verigreen/buildverification/JenkinsVerifierMockFactory.java
+++ b/verigreen-collector-impl/src/test/java/com/verigreen/buildverification/JenkinsVerifierMockFactory.java
@@ -19,7 +19,10 @@ import com.verigreen.collector.buildverification.BuildVerifier;
 public class JenkinsVerifierMockFactory {
     
     private static BuildVerifier _buildVerifier = EasyMock.createNiceMock(BuildVerifier.class);
-    
+
+    private JenkinsVerifierMockFactory() {
+    }
+
     public static BuildVerifier getMock() {
         
         return _buildVerifier;

--- a/verigreen-collector-impl/src/test/java/com/verigreen/common/util/CommitItemFactory.java
+++ b/verigreen-collector-impl/src/test/java/com/verigreen/common/util/CommitItemFactory.java
@@ -19,7 +19,10 @@ import com.verigreen.collector.spring.CollectorApi;
 import com.verigreen.common.utils.StringUtils;
 
 public class CommitItemFactory {
-    
+
+    private CommitItemFactory() {
+    }
+
     public static CommitItem create(VerificationStatus status, String protectedBranch) {
         
         return create(

--- a/vg-common/src/com/verigreen/common/concurrency/RuntimeUtils.java
+++ b/vg-common/src/com/verigreen/common/concurrency/RuntimeUtils.java
@@ -18,7 +18,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RuntimeUtils {
-    
+
+    private RuntimeUtils() {
+    }
+
     public static boolean isDebuggerAttached() {
         
         boolean isDebug =

--- a/vg-common/src/com/verigreen/common/utils/CloneUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/CloneUtils.java
@@ -16,7 +16,10 @@ import java.io.Serializable;
 
 
 public class CloneUtils {
-    
+
+    private CloneUtils() {
+    }
+
     public static <TValue extends Serializable> TValue clone(TValue clonable) {
         
         ObjectCopier<TValue> copier = new ObjectCopier<TValue>();

--- a/vg-common/src/com/verigreen/common/utils/CollectionUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/CollectionUtils.java
@@ -17,7 +17,10 @@ import java.util.Iterator;
 import java.util.List;
 
 public class CollectionUtils {
-    
+
+    private CollectionUtils() {
+    }
+
     public static boolean isEquals(List<String> left, List<String> right) {
         
         boolean ret = false;

--- a/vg-common/src/com/verigreen/common/utils/DirectoryUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/DirectoryUtils.java
@@ -16,7 +16,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class DirectoryUtils {
-    
+
+    private DirectoryUtils() {
+    }
+
     /**
      * Returns a path to the given directory, if such can be resolved from your current path.
      * 

--- a/vg-common/src/com/verigreen/common/utils/EmailUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/EmailUtils.java
@@ -22,7 +22,10 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
 public class EmailUtils {
-    
+
+    private EmailUtils() {
+    }
+
     public static void send(
             String subject,
             String messageText,

--- a/vg-common/src/com/verigreen/common/utils/GsonSerializer.java
+++ b/vg-common/src/com/verigreen/common/utils/GsonSerializer.java
@@ -17,7 +17,10 @@ import com.google.gson.Gson;
 public class GsonSerializer {
     
     private static final Gson _gson = new Gson();
-    
+
+    private GsonSerializer() {
+    }
+
     /**
      * Serialize a generic object to json
      */

--- a/vg-common/src/com/verigreen/common/utils/HtmlUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/HtmlUtils.java
@@ -15,4 +15,7 @@ package com.verigreen.common.utils;
 public class HtmlUtils {
 
     public static final String NEW_LINE = "<br>";
+
+    private HtmlUtils() {
+    }
 }

--- a/vg-common/src/com/verigreen/common/utils/PropertiesUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/PropertiesUtils.java
@@ -22,7 +22,10 @@ import java.util.Properties;
  * 
  */
 public class PropertiesUtils {
-    
+
+    private PropertiesUtils() {
+    }
+
     /**
      * First tries to get the propertyName from the environment variables. <br>
      * If does not exist - gets from props. <br>

--- a/vg-common/src/com/verigreen/common/utils/ReflectionComparer.java
+++ b/vg-common/src/com/verigreen/common/utils/ReflectionComparer.java
@@ -17,7 +17,10 @@ import java.lang.reflect.Method;
 import com.verigreen.common.exception.LabException;
 
 public class ReflectionComparer {
-    
+
+    private ReflectionComparer() {
+    }
+
     public static <T> boolean isEquals(T x, T y) {
         
         boolean ret = true;

--- a/vg-common/src/com/verigreen/common/utils/StringUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/StringUtils.java
@@ -22,7 +22,10 @@ public class StringUtils {
     public static final String SPACE = " ";
     public static final String PERIOD = ".";
     public static final String TAB = "\t";
-    
+
+    private StringUtils() {
+    }
+
     public static boolean isNullOrEmpty(String value) {
         
         return (value == null) || (value.length() == 0);

--- a/vg-common/src/com/verigreen/common/utils/SystemOut.java
+++ b/vg-common/src/com/verigreen/common/utils/SystemOut.java
@@ -19,7 +19,10 @@ import com.verigreen.common.concurrency.RuntimeUtils;
 public class SystemOut {
     
     private static boolean isInProductionMode = RuntimeUtils.isInProductionMode();
-    
+
+    private SystemOut() {
+    }
+
     public static void println(String x) {
         
         if (!isInProductionMode) {

--- a/vg-common/src/com/verigreen/common/utils/TimeUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/TimeUtils.java
@@ -17,7 +17,10 @@ import java.sql.Timestamp;
 public class TimeUtils {
     
     public final static long UNINITIALIZED = 0;
-    
+
+    private TimeUtils() {
+    }
+
     public static long timeSpanInSeconds(long time1, long time2) {
         
         return (time2 - time1) / 1000;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
