### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/jenkins-client/src/com/offbytwo/jenkins/model/BuildWithDetails.java
+++ b/jenkins-client/src/com/offbytwo/jenkins/model/BuildWithDetails.java
@@ -74,7 +74,7 @@ public class BuildWithDetails extends Build {
             }
         });
 
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
 
         if (parameters != null && !parameters.isEmpty()) {
             for (Map<String, Object> param : ((Map<String, List<Map<String, Object>>>) parameters.toArray()[0]).get("parameters")) {

--- a/verigreen-collector-api/src/com/verigreen/jgit/JGitOperator.java
+++ b/verigreen-collector-api/src/com/verigreen/jgit/JGitOperator.java
@@ -232,7 +232,7 @@ public class JGitOperator implements SourceControlOperator {
             Iterable<PushResult> results = command.call();
             for (PushResult pushResult : results) {
             	Collection<RemoteRefUpdate> resultsCollection = pushResult.getRemoteUpdates();
-            	Map<PushResult,RemoteRefUpdate> resultsMap = new HashMap<PushResult,RemoteRefUpdate>();
+            	Map<PushResult,RemoteRefUpdate> resultsMap = new HashMap<>();
             	for(RemoteRefUpdate remoteRefUpdate : resultsCollection)
             	{
             		resultsMap.put(pushResult, remoteRefUpdate);
@@ -341,7 +341,7 @@ public class JGitOperator implements SourceControlOperator {
     
     public Pair<Boolean, String> merge(String branchToUpdate, String branchHead, boolean commit) {
         
-        Pair<Boolean, String> ret = new Pair<Boolean, String>(false, "");
+        Pair<Boolean, String> ret = new Pair<>(false, "");
         MergeCommand command = _git.merge();
         try {
             String refName =
@@ -476,7 +476,7 @@ public class JGitOperator implements SourceControlOperator {
                             "Merge not needed for parent_branch:%s into:%s",
                             branchHead,
                             branchToUpdate));
-            ret = new Pair<Boolean, String>(true, "");
+            ret = new Pair<>(true, "");
         } else if (mergeResult.getMergeStatus().equals(MergeStatus.MERGED_NOT_COMMITTED)) {
             String autoMergeMessage = createMessageAutoCommit(mergeResult);
 			String commitId = commit(commited_By_Collector, email_Address, autoMergeMessage );
@@ -489,13 +489,13 @@ public class JGitOperator implements SourceControlOperator {
                             branchHead,
                             branchToUpdate,
                             adjustCommitId));
-            ret = new Pair<Boolean, String>(true, adjustCommitId);
+            ret = new Pair<>(true, adjustCommitId);
         }else if (mergeResult.getMergeStatus().equals(MergeStatus.MERGED)) {
          VerigreenLogger.get().log(
                  getClass().getName(),
                  RuntimeUtils.getCurrentMethodName(),
                  "Merge was made after diverted branch with auto commit");
-         ret = new Pair<Boolean, String>(true, "");
+         ret = new Pair<>(true, "");
          new RestClientImpl().post(CollectorApi.getPostVerigreenNeededRequest(mergeResult.getNewHead().getName().substring(0, 7)));
      }
         return ret;
@@ -523,7 +523,7 @@ public class JGitOperator implements SourceControlOperator {
 
 	@Override
 	public List<String> retreiveBranches() {
-		List <String> receivedListAsString = new ArrayList<String>();
+		List <String> receivedListAsString = new ArrayList<>();
 		List <Ref> receivedList;
 		try {
 			receivedList = _git.branchList().setListMode(ListMode.ALL).call();

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/buildverification/CommitItemCanceler.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/buildverification/CommitItemCanceler.java
@@ -19,7 +19,7 @@ import com.verigreen.collector.model.CommitItem;
 
 public class CommitItemCanceler {
 
-	private List<CommitItem> commitsToStop = new ArrayList<CommitItem>();
+	private List<CommitItem> commitsToStop = new ArrayList<>();
     private static volatile CommitItemCanceler instance = null;
     
 	protected CommitItemCanceler() {

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/buildverification/JenkinsUpdater.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/buildverification/JenkinsUpdater.java
@@ -23,7 +23,7 @@ public class JenkinsUpdater implements Subject {
     // Map to make the correlation between the build results from Jenkins and the VerificationStatus class
 	static
     {
-    	_verificationStatusesMap = new HashMap<String, VerificationStatus>();
+    	_verificationStatusesMap = new HashMap<>();
     	_verificationStatusesMap.put(BuildResult.SUCCESS.toString(), VerificationStatus.PASSED);
     	_verificationStatusesMap.put(BuildResult.ABORTED.toString(), VerificationStatus.FAILED);
     	_verificationStatusesMap.put(BuildResult.FAILURE.toString(), VerificationStatus.FAILED);
@@ -78,7 +78,7 @@ public class JenkinsUpdater implements Subject {
 	public List<Observer> setObserversStatus(List<Observer> relevantObservers, Map <String, MinJenkinsJob> results)
 	{
 		//sets the observer status based on the result recieved from Jenkins
-		List<Observer> notifiedObservers = new ArrayList<Observer>();
+		List<Observer> notifiedObservers = new ArrayList<>();
 		MinJenkinsJob result;
 		for(Observer observer : relevantObservers)
 		{	
@@ -93,7 +93,7 @@ public class JenkinsUpdater implements Subject {
 	public void notifyObserver(List<Observer> relevantObservers) 
 	{
 	//the relevant observers are notified, unregistered and saved to the commit item container	
-		List<CommitItem> notifiedObservers = new ArrayList<CommitItem>();
+		List<CommitItem> notifiedObservers = new ArrayList<>();
 		for(Observer observer : relevantObservers){
 			if(!com.verigreen.collector.spring.CollectorApi.getCommitItemContainer().get(((CommitItem)observer).getKey()).getStatus().isFinalState()) {
 				notifiedObservers.add((CommitItem)observer);

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/common/CommitItemUtils.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/common/CommitItemUtils.java
@@ -106,7 +106,7 @@ public class CommitItemUtils {
     }
     
     public static void createJsonFile(CommitItem localCommitItem, boolean canceledItem) throws JSONException, IOException {
-		List<JSONObject> objectList = new ArrayList<JSONObject>();
+		List<JSONObject> objectList = new ArrayList<>();
 		JSONObject jsonObject = new JSONObject();
 		String parent = localCommitItem.getParent() !=null ? localCommitItem.getParent().getBranchDescriptor().getNewBranch()
                 : localCommitItem.getBranchDescriptor().getProtectedBranch();

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/common/VerigreenNeededLogic.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/common/VerigreenNeededLogic.java
@@ -47,9 +47,9 @@ import com.verigreen.jgit.SourceControlOperator;
 
 public class VerigreenNeededLogic {
 	public static Properties properties = new Properties();
-	public static Map<String,String> VerigreenMap = new HashMap<String,String>();
-	public static Map<String,String> jenkinsParams = new HashMap<String,String>();
-	public static Map<String,List<JSONObject>> history = new HashMap<String,List<JSONObject>>();
+	public static Map<String,String> VerigreenMap = new HashMap<>();
+	public static Map<String,String> jenkinsParams = new HashMap<>();
+	public static Map<String,List<JSONObject>> history = new HashMap<>();
 	private String vgHomePath = System.getenv("VG_HOME");
 	private String historyJsonPath = vgHomePath + "//history.json";
 
@@ -111,7 +111,7 @@ public class VerigreenNeededLogic {
 		            while( keys.hasNext() ){
 		                key = (String)keys.next();
 		                keyValues = jObject.getJSONArray(key);
-		                values = new ArrayList<JSONObject>();
+		                values = new ArrayList<>();
 		                for(int i = 0; i < keyValues.length(); i++)
 		                {
 			                values.add(keyValues.getJSONObject(i));
@@ -221,7 +221,7 @@ public class VerigreenNeededLogic {
 		if (ans) {
 			CommitItem item =
 					checkIfCommitItemExists(parentBranchName, branchNameToVerify, commitId);
-			List<String> passCommit = VerigreenMap.get("_passCommit") != null? new LinkedList<String>(Arrays.asList(VerigreenMap.get("_passCommit").split("\\s*,\\s*"))):null;
+			List<String> passCommit = VerigreenMap.get("_passCommit") != null? new LinkedList<>(Arrays.asList(VerigreenMap.get("_passCommit").split("\\s*,\\s*"))):null;
 			
 			if (item != null){
 				// commit item already exists -> don't do verigreen
@@ -321,7 +321,7 @@ public class VerigreenNeededLogic {
 	 */
 	public static Map<String, String> checkJenkinsMode(CommitItem commitItem) {	
 		
-		Map<String, String> resultMap =  new HashMap<String,String>();
+		Map<String, String> resultMap = new HashMap<>();
 		Map<String, String> paramMap = commitItemAsParameterMap(commitItem);
 
 		if(jenkinsParams.get("jenkinsparam.mode") != null && jenkinsParams.get("jenkinsparam.mode").equals("json")){
@@ -345,7 +345,7 @@ public class VerigreenNeededLogic {
 	 */
 	public static Map<String, String> commitItemAsParameterMap(CommitItem commitItem) {	
 		
-		Map<String, String> returnedForJenkins = new HashMap<String,String>();
+		Map<String, String> returnedForJenkins = new HashMap<>();
 		for(String key : jenkinsParams.keySet())
 		{
 			if(key.contains("commitid")){

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/decision/decisionmaker/ProtectedBranchesDecisionMaker.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/decision/decisionmaker/ProtectedBranchesDecisionMaker.java
@@ -36,7 +36,7 @@ public class ProtectedBranchesDecisionMaker {
         Collection<List<Decision>> ret = new ArrayList<>();
         CommitItem item = null;
         try {
-        	ArrayList<CommitItem> notStarted = new ArrayList<CommitItem>(CommitItemUtils.filterItems(CommitItemUtils.getNotDone(), VerificationStatus.NOT_STARTED));
+        	ArrayList<CommitItem> notStarted = new ArrayList<>(CommitItemUtils.filterItems(CommitItemUtils.getNotDone(), VerificationStatus.NOT_STARTED));
             Collection<CommitItem> notDone = CommitItemUtils.getNotDone();
             notDone.removeAll(notStarted);            
             while(notDone.size()<numberCommits && !notStarted.isEmpty()) {

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/BranchCleanerJob.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/BranchCleanerJob.java
@@ -62,13 +62,13 @@ public class BranchCleanerJob implements Job{
 	}
 
 	private List <String> branchesToBeDelete(List <String> branchesList){
-		List<String> result = new ArrayList<String>();
+		List<String> result = new ArrayList<>();
 		Repository repo = null;
-		Map<String, List <String>> branchesMap = new HashMap<String, List <String>>();
+		Map<String, List <String>> branchesMap = new HashMap<>();
 		for (String branch : branchesList) {
 			List<String> values = null;
 			if (!branchesMap.containsKey(branch.subSequence(0, 10))){
-				values = new ArrayList<String>();
+				values = new ArrayList<>();
 				values.add(branch);
 				branchesMap.put(branch.subSequence(0, 10).toString(), values);
 			}

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/CallJenkinsJob.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/CallJenkinsJob.java
@@ -174,7 +174,7 @@ public class CallJenkinsJob implements Job {
 	             RuntimeUtils.getCurrentMethodName(),
 	             String.format(
 	                     "Parsing JSON results fron Jenkins..."));
-		Map<String, MinJenkinsJob> buildsAndStatusesMap = new HashMap<String, MinJenkinsJob>();
+		Map<String, MinJenkinsJob> buildsAndStatusesMap = new HashMap<>();
 		JsonParser parser = new JsonParser();
 		JsonObject mainJson = (JsonObject) parser.parse(json);
 		
@@ -296,7 +296,7 @@ public class CallJenkinsJob implements Job {
 	                     "Analyzing JSON results and returning the relevant observers..."));
 
 		List<Observer> observers =  jenkinsUpdater.getObservers();
-		List<Observer> relevantObservers = new ArrayList<Observer>();
+		List<Observer> relevantObservers = new ArrayList<>();
 		for(Observer observer : observers)
 		{	
 			observer = com.verigreen.collector.spring.CollectorApi.getCommitItemContainer().get(((CommitItem)observer).getKey());

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/HistoryCleanerJob.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/HistoryCleanerJob.java
@@ -44,7 +44,7 @@ public class HistoryCleanerJob implements Job {
 	}
 
 	private void getHistory() {
-		Map<String,List<JSONObject>> newHistory = new HashMap<String,List<JSONObject>>();
+		Map<String,List<JSONObject>> newHistory = new HashMap<>();
 		List<CommitItem> commitItems = CollectorApi.getCommitItemContainer().getAll();
 		
 		for (CommitItem commit : commitItems) {

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/rest/CommitMessage.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/rest/CommitMessage.java
@@ -36,7 +36,7 @@ public class CommitMessage {
 	@GET
     @Produces(MediaType.APPLICATION_JSON)
 	public static Response get() {
-		Map<String,String> logMessages = new HashMap<String,String>();
+		Map<String,String> logMessages = new HashMap<>();
 		try {
 		FileRepositoryBuilder builder = new FileRepositoryBuilder();
 	     Repository repo = builder.setGitDir(new File(VerigreenNeededLogic.properties.getProperty("git.repositoryLocation"))).setMustExist(true).build();

--- a/verigreen-collector-impl/src/test/java/com/verigreen/common/util/SourceControlOperatorMock.java
+++ b/verigreen-collector-impl/src/test/java/com/verigreen/common/util/SourceControlOperatorMock.java
@@ -101,7 +101,7 @@ public class SourceControlOperatorMock implements SourceControlOperator {
         EasyMock.expect(_mock.checkout(protectedBranch, false, false)).andReturn(protectedBranch);
         EasyMock.expect(_mock.checkout(mergedBranch, false, false)).andReturn(mergedBranch);
         EasyMock.expect(_mock.merge(EasyMock.anyString(), EasyMock.anyString())).andReturn(
-                new Pair<Boolean, String>(mergeResult, "")).times(2);
+                new Pair<>(mergeResult, "")).times(2);
         EasyMock.expect(_mock.push(protectedBranch, protectedBranch)).andReturn(true);
         EasyMock.expect(_mock.push(mergedBranch, mergedBranch)).andReturn(true).atLeastOnce();
         if (updateBranchWithParentThrowsException) {
@@ -121,7 +121,7 @@ public class SourceControlOperatorMock implements SourceControlOperator {
                             EasyMock.eq(false),
                             EasyMock.eq(false),
                             EasyMock.eq(false))).andReturn(
-                    new Pair<Boolean, String>(mergeResult, "")).times(2);
+                    new Pair<>(mergeResult, "")).times(2);
         }
         EasyMock.expect(_mock.getPathOfLocalRepository()).andReturn("");
         EasyMock.expect(_mock.commit("", "", "")).andReturn("");

--- a/vg-common/src/com/verigreen/common/cache/Container.java
+++ b/vg-common/src/com/verigreen/common/cache/Container.java
@@ -20,7 +20,7 @@ import com.verigreen.common.utils.StringUtils;
 
 public abstract class Container<TEntity extends Entity> {
     
-    protected final UniqueIndex<String, TEntity> _keyToEntity = new UniqueIndex<String, TEntity>();
+    protected final UniqueIndex<String, TEntity> _keyToEntity = new UniqueIndex<>();
     
     public TEntity get(String id) {
         

--- a/vg-common/src/com/verigreen/common/cache/SequenceManager.java
+++ b/vg-common/src/com/verigreen/common/cache/SequenceManager.java
@@ -25,7 +25,7 @@ public class SequenceManager {
     
     private final static SequenceManager _instance = new SequenceManager();
     private final Map<Class<? extends Entity>, AtomicInteger> _entitiesToSequences =
-            new ConcurrentHashMap<Class<? extends Entity>, AtomicInteger>();
+            new ConcurrentHashMap<>();
     private final int _seed = 0;
     
     private SequenceManager() {}

--- a/vg-common/src/com/verigreen/common/cache/UniqueIndex.java
+++ b/vg-common/src/com/verigreen/common/cache/UniqueIndex.java
@@ -29,7 +29,7 @@ public class UniqueIndex<TKey, TValue extends Serializable> extends Index<TKey, 
     
     public List<TValue> getAll() {
         
-        List<TValue> ret = new ArrayList<TValue>();
+        List<TValue> ret = new ArrayList<>();
         for (Entry<TKey, TValue> entry : _map.entrySet()) {
             ret.add(entry.getValue());
         }

--- a/vg-common/src/com/verigreen/common/command/TEQCommandExecuter.java
+++ b/vg-common/src/com/verigreen/common/command/TEQCommandExecuter.java
@@ -42,7 +42,7 @@ public class TEQCommandExecuter {
             KeepWaitingPolicy<?> keepWaitingPolicy) {
         
         _timeBoundedExecuter.perform(
-                new RunnableExecuter<TCommandParameters>(
+                new RunnableExecuter<>(
                         commandPack.getCommand(),
                         commandPack.getParameters()),
                 _timeoutMillis,
@@ -53,7 +53,7 @@ public class TEQCommandExecuter {
             CommandPack<TCommandParameters> commandPack) {
         
         _timeBoundedExecuter.perform(
-                new RunnableExecuter<TCommandParameters>(
+                new RunnableExecuter<>(
                         commandPack.getCommand(),
                         commandPack.getParameters()),
                 _timeoutMillis);

--- a/vg-common/src/com/verigreen/common/concurrency/GracefulThreadPoolExecutor.java
+++ b/vg-common/src/com/verigreen/common/concurrency/GracefulThreadPoolExecutor.java
@@ -46,7 +46,7 @@ public class GracefulThreadPoolExecutor extends ThreadPoolExecutor {
         if (tasks == null || unit == null)
             throw new NullPointerException();
         long nanos = unit.toNanos(timeout);
-        List<Future<T>> futures = new ArrayList<Future<T>>(tasks.size());
+        List<Future<T>> futures = new ArrayList<>(tasks.size());
         for (Callable<T> t : tasks)
             futures.add(newTaskFor(t));
         

--- a/vg-common/src/com/verigreen/common/concurrency/Locker.java
+++ b/vg-common/src/com/verigreen/common/concurrency/Locker.java
@@ -24,7 +24,7 @@ public class Locker {
     
     private static Locker _instance = new Locker();
     private final ConcurrentMap<Integer, LockerData> _data =
-            new ConcurrentHashMap<Integer, LockerData>();
+            new ConcurrentHashMap<>();
     
     private Locker() {}
     

--- a/vg-common/src/com/verigreen/common/concurrency/ResourceFinder.java
+++ b/vg-common/src/com/verigreen/common/concurrency/ResourceFinder.java
@@ -52,7 +52,7 @@ public class ResourceFinder {
     private final URL[] _urls;
     private final String _path;
     private final ClassLoader _classLoader;
-    private final List<String> _resourcesNotLoaded = new ArrayList<String>();
+    private final List<String> _resourcesNotLoaded = new ArrayList<>();
     
     public ResourceFinder(URL... urls) {
         
@@ -188,7 +188,7 @@ public class ResourceFinder {
     public List<String> findAllStrings(String uri) throws IOException {
         String fulluri = _path + uri;
         
-        List<String> strings = new ArrayList<String>();
+        List<String> strings = new ArrayList<>();
         
         Enumeration<URL> resources = getResources(fulluri);
         while (resources.hasMoreElements()) {
@@ -212,7 +212,7 @@ public class ResourceFinder {
         _resourcesNotLoaded.clear();
         String fulluri = _path + uri;
         
-        List<String> strings = new ArrayList<String>();
+        List<String> strings = new ArrayList<>();
         
         Enumeration<URL> resources = getResources(fulluri);
         while (resources.hasMoreElements()) {
@@ -249,7 +249,7 @@ public class ResourceFinder {
      */
     public Map<String, String> mapAllStrings(String uri) throws IOException {
         
-        Map<String, String> strings = new HashMap<String, String>();
+        Map<String, String> strings = new HashMap<>();
         Map<String, URL> resourcesMap = getResourcesMap(uri);
         for (Iterator<Entry<String, URL>> iterator = resourcesMap.entrySet().iterator(); iterator.hasNext();) {
             Entry<String, URL> entry = iterator.next();
@@ -285,7 +285,7 @@ public class ResourceFinder {
     public Map<String, String> mapAvailableStrings(String uri) throws IOException {
         
         _resourcesNotLoaded.clear();
-        Map<String, String> strings = new HashMap<String, String>();
+        Map<String, String> strings = new HashMap<>();
         Map<String, URL> resourcesMap = getResourcesMap(uri);
         for (Iterator<Entry<String, URL>> iterator = resourcesMap.entrySet().iterator(); iterator.hasNext();) {
             Entry<String, URL> entry = iterator.next();
@@ -732,7 +732,7 @@ public class ResourceFinder {
     public List<Properties> findAllProperties(String uri) throws IOException {
         String fulluri = _path + uri;
         
-        List<Properties> properties = new ArrayList<Properties>();
+        List<Properties> properties = new ArrayList<>();
         
         Enumeration<URL> resources = getResources(fulluri);
         while (resources.hasMoreElements()) {
@@ -765,7 +765,7 @@ public class ResourceFinder {
         _resourcesNotLoaded.clear();
         String fulluri = _path + uri;
         
-        List<Properties> properties = new ArrayList<Properties>();
+        List<Properties> properties = new ArrayList<>();
         
         Enumeration<URL> resources = getResources(fulluri);
         while (resources.hasMoreElements()) {
@@ -802,7 +802,7 @@ public class ResourceFinder {
      */
     public Map<String, Properties> mapAllProperties(String uri) throws IOException {
         
-        Map<String, Properties> propertiesMap = new HashMap<String, Properties>();
+        Map<String, Properties> propertiesMap = new HashMap<>();
         Map<String, URL> map = getResourcesMap(uri);
         for (Iterator<Entry<String, URL>> iterator = map.entrySet().iterator(); iterator.hasNext();) {
             Entry<String, URL> entry = iterator.next();
@@ -839,7 +839,7 @@ public class ResourceFinder {
     public Map<String, Properties> mapAvailableProperties(String uri) throws IOException {
         
         _resourcesNotLoaded.clear();
-        Map<String, Properties> propertiesMap = new HashMap<String, Properties>();
+        Map<String, Properties> propertiesMap = new HashMap<>();
         Map<String, URL> map = getResourcesMap(uri);
         for (Iterator<Entry<String, URL>> iterator = map.entrySet().iterator(); iterator.hasNext();) {
             Entry<String, URL> entry = iterator.next();
@@ -865,7 +865,7 @@ public class ResourceFinder {
     public Map<String, URL> getResourcesMap(String uri) throws IOException {
         
         String basePath = _path + uri;
-        Map<String, URL> resources = new HashMap<String, URL>();
+        Map<String, URL> resources = new HashMap<>();
         if (!basePath.endsWith("/")) {
             basePath += "/";
         }

--- a/vg-common/src/com/verigreen/common/concurrency/RuntimeUtils.java
+++ b/vg-common/src/com/verigreen/common/concurrency/RuntimeUtils.java
@@ -62,7 +62,7 @@ public class RuntimeUtils {
             Field[] fields,
             Class<? extends Annotation> annotation) {
         
-        List<Field> ret = new ArrayList<Field>();
+        List<Field> ret = new ArrayList<>();
         for (Field field : fields) {
             if (field.isAnnotationPresent(annotation))
                 ret.add(field);

--- a/vg-common/src/com/verigreen/common/concurrency/timeboundedexecuter/TimeBoundedExecuter.java
+++ b/vg-common/src/com/verigreen/common/concurrency/timeboundedexecuter/TimeBoundedExecuter.java
@@ -81,9 +81,9 @@ public class TimeBoundedExecuter {
     private <TResult> List<TimeBoundedThread<TResult>> createTimeBoundedThreads(
             List<Action<TResult>> actionDelegate) {
         
-        List<TimeBoundedThread<TResult>> tasks = new ArrayList<TimeBoundedThread<TResult>>();
+        List<TimeBoundedThread<TResult>> tasks = new ArrayList<>();
         for (Action<TResult> action : actionDelegate) {
-            tasks.add(new TimeBoundedThread<TResult>(action));
+            tasks.add(new TimeBoundedThread<>(action));
         }
         
         return tasks;
@@ -94,7 +94,7 @@ public class TimeBoundedExecuter {
             long timeBoundInMillis,
             TimeBoundedPolicy policy) {
         
-        TimeBoundedThread<T> timeBoundedThread = new TimeBoundedThread<T>(actionDelegate);
+        TimeBoundedThread<T> timeBoundedThread = new TimeBoundedThread<>(actionDelegate);
         Future<T> future = _executerService.submit(timeBoundedThread);
         T retVal = loopWhileStillNotFinished(actionDelegate, timeBoundInMillis, future, policy);
         

--- a/vg-common/src/com/verigreen/common/jbosscache/CacheInstance.java
+++ b/vg-common/src/com/verigreen/common/jbosscache/CacheInstance.java
@@ -40,7 +40,7 @@ public class CacheInstance {
     
     public void start() {
         
-        CacheFactory<String, Object> factory = new DefaultCacheFactory<String, Object>();
+        CacheFactory<String, Object> factory = new DefaultCacheFactory<>();
         String configFileName = CONFIG_PATH;
         _cache = factory.createCache(configFileName, false);
         _cache.create();

--- a/vg-common/src/com/verigreen/common/jbosscache/EntityContainer.java
+++ b/vg-common/src/com/verigreen/common/jbosscache/EntityContainer.java
@@ -130,7 +130,7 @@ public abstract class EntityContainer<K, V extends Entity<K>> implements
     public List<V> getAll() {
         
         Node<String, Object> cache = getCache().getNode(Fqn.fromString(_cacheName));
-        ArrayList<V> list = new ArrayList<V>();
+        ArrayList<V> list = new ArrayList<>();
         if (cache != null) {
             populateValues(cache, list);
         }
@@ -167,7 +167,7 @@ public abstract class EntityContainer<K, V extends Entity<K>> implements
     
     protected List<V> internalFindByCriteria(Criteria<V> criteria, List<V> items) {
         
-        List<V> foundItems = new ArrayList<V>();
+        List<V> foundItems = new ArrayList<>();
         
         for (V wi : items) {
             if (criteria.match(wi)) {

--- a/vg-common/src/com/verigreen/common/spring/SpringContextLoader.java
+++ b/vg-common/src/com/verigreen/common/spring/SpringContextLoader.java
@@ -69,7 +69,7 @@ public class SpringContextLoader extends AbstractContextLoader {
         String[] ecLocations = getLocationsToLoad();
         
         int size = ecLocations.length + additionalLocations.size();
-        ArrayList<String> newLocations = new ArrayList<String>(size);
+        ArrayList<String> newLocations = new ArrayList<>(size);
         Collections.addAll(newLocations, ecLocations);
         
         // this line needs to be at the end so that any mock contexts will override normal contexts

--- a/vg-common/src/com/verigreen/common/utils/CloneUtils.java
+++ b/vg-common/src/com/verigreen/common/utils/CloneUtils.java
@@ -19,7 +19,7 @@ public class CloneUtils {
     
     public static <TValue extends Serializable> TValue clone(TValue clonable) {
         
-        ObjectCopier<TValue> copier = new ObjectCopier<TValue>();
+        ObjectCopier<TValue> copier = new ObjectCopier<>();
         copier.copyObject(clonable);
         
         return copier.pasteObject();

--- a/vg-common/utest/com/verigreen/common/concurrency/SynchronizeableThreadPoolExecutor.java
+++ b/vg-common/utest/com/verigreen/common/concurrency/SynchronizeableThreadPoolExecutor.java
@@ -24,7 +24,7 @@ import com.verigreen.common.exception.LabException;
 
 public class SynchronizeableThreadPoolExecutor extends GracefulThreadPoolExecutor {
     
-    Collection<Future<?>> _tasks = new LinkedList<Future<?>>();
+    Collection<Future<?>> _tasks = new LinkedList<>();
     
     public SynchronizeableThreadPoolExecutor() {
         


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.
