### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/buildverification/JenkinsVerifier.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/buildverification/JenkinsVerifier.java
@@ -51,7 +51,7 @@ public class JenkinsVerifier implements BuildVerifier {
 	                RuntimeUtils.getCurrentMethodName(),
 	                String.format(
 	                        "Attempting to retrieve job for verification...", retries));
-			jobToVerify = CollectorApi.getJenkinsServer().getJob((CollectorApi.getVerificationJobName().toLowerCase()));	
+			jobToVerify = CollectorApi.getJenkinsServer().getJob(CollectorApi.getVerificationJobName().toLowerCase());	
 			if(jobToVerify != null)
 			{
 				VerigreenLogger.get().log(

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/common/VerigreenNeededLogic.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/common/VerigreenNeededLogic.java
@@ -298,9 +298,9 @@ public class VerigreenNeededLogic {
 					@Override
 					public boolean match(CommitItem entity) {
 
-						return ((entity.getBranchDescriptor().getNewBranch().equals(
+						return (entity.getBranchDescriptor().getNewBranch().equals(
 								branchNameToVerify) || (entity.getChildCommit().equals(commitId))) && entity.getBranchDescriptor().getProtectedBranch().equals(
-										parentBranchName));
+										parentBranchName);
 					}
 				});
 

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/BranchCleanerJob.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/BranchCleanerJob.java
@@ -58,7 +58,7 @@ public class BranchCleanerJob implements Job{
 		_jgit = (JGitOperator)SpringContextHolder.getInstance().getBean("jgitOperator");
 		List <String> branchesToBeDeleteList = branchesToBeDelete(_jgit.getBranchesList(_jgit.retreiveBranches()));
 		if(!CollectionUtils.isNullOrEmpty(branchesToBeDeleteList))
-			_jgit.deleteBranch(true,(branchesToBeDeleteList.toArray(new String[branchesToBeDeleteList.size()])));
+			_jgit.deleteBranch(true, branchesToBeDeleteList.toArray(new String[branchesToBeDeleteList.size()]));
 	}
 
 	private List <String> branchesToBeDelete(List <String> branchesList){

--- a/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/CallJenkinsJob.java
+++ b/verigreen-collector-impl/src/main/java/com/verigreen/collector/jobs/CallJenkinsJob.java
@@ -323,7 +323,7 @@ public class CallJenkinsJob implements Job {
 						((CommitItem)observer).setBuildNumber(Integer.parseInt(parsedResults.get(((CommitItem)observer).getMergedBranchName()).getBuildNumber()));
 						((CommitItem)observer).setBuildUrl(new URI (JenkinsVerifier.getBuildUrl(Integer.parseInt(parsedResults.get(((CommitItem)observer).getMergedBranchName()).getBuildNumber()))));
 						
-						com.verigreen.collector.spring.CollectorApi.getCommitItemContainer().save(((CommitItem)observer));
+						com.verigreen.collector.spring.CollectorApi.getCommitItemContainer().save((CommitItem)observer);
 					}
 					
 				}

--- a/vg-common/src/com/verigreen/common/utils/Pair.java
+++ b/vg-common/src/com/verigreen/common/utils/Pair.java
@@ -46,9 +46,9 @@ public class Pair<TFirst, TSecond> {
         if (other instanceof Pair) {
             Pair<?, ?> otherPair = (Pair<?, ?>) other;
             ret =
-                    (((_first == otherPair._first) || ((_first != null)
+                    ((_first == otherPair._first) || ((_first != null)
                                                        && (otherPair._first != null) && _first.equals(otherPair._first))) && ((_second == otherPair._second) || ((_second != null)
-                                                                                                                                                                 && (otherPair._second != null) && _second.equals(otherPair._second))));
+                                                                                                                                                                 && (otherPair._second != null) && _second.equals(otherPair._second)));
         }
         
         return ret;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
